### PR TITLE
Allow different registry. Fix naming conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Building the Docker image
 
 > [!NOTE]
-> You will need to edit the `docker-bake.hcl` file and update `USERNAME`,
+> You will need to edit the `docker-bake.hcl` file and update `REGISTRY_USER`,
 > and `RELEASE`.  You can obviously edit the other values too, but these
 > are the most important ones.
 
@@ -30,6 +30,10 @@ docker login
 
 # Build the image, tag the image, and push the image to Docker Hub
 docker buildx bake -f docker-bake.hcl --push
+
+# Build a specific target for a different user, registry and release version
+REGISTRY=ghcr.io REGISTRY_USER=my_gh_user RELEASE=x.y.z docker buildx bake \
+    -f docker-bake.hcl --push cu118-torch212
 ```
 
 ## Community and Contributing

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,4 +1,8 @@
-variable "USERNAME" {
+variable "REGISTRY" {
+    default = "docker.io"
+}
+
+variable "REGISTRY_USER" {
     default = "ashleykza"
 }
 
@@ -16,7 +20,7 @@ group "default" {
 
 target "cu118-torch212" {
     dockerfile = "Dockerfile.with-xformers"
-    tags = ["${USERNAME}/runpod-base:${RELEASE}-cuda11.8.0-torch2.1.2"]
+    tags = ["${REGISTRY}/${REGISTRY_USER}/runpod-base:${RELEASE}-cuda11.8.0-torch2.1.2"]
     args = {
         BASE_IMAGE = "nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04"
         RELEASE = "${RELEASE}"
@@ -29,7 +33,7 @@ target "cu118-torch212" {
 
 target "cu118-torch222" {
     dockerfile = "Dockerfile.with-xformers"
-    tags = ["${USERNAME}/runpod-base:${RELEASE}-cuda11.8.0-torch2.2.2"]
+    tags = ["${REGISTRY}/${REGISTRY_USER}/runpod-base:${RELEASE}-cuda11.8.0-torch2.2.2"]
     args = {
         BASE_IMAGE = "nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04"
         RELEASE = "${RELEASE}"
@@ -42,7 +46,7 @@ target "cu118-torch222" {
 
 target "cu121-torch221" {
     dockerfile = "Dockerfile.without-xformers"
-    tags = ["${USERNAME}/runpod-base:${RELEASE}-cuda12.1.1-torch2.2.1"]
+    tags = ["${REGISTRY}/${REGISTRY_USER}/runpod-base:${RELEASE}-cuda12.1.1-torch2.2.1"]
     args = {
         BASE_IMAGE = "nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04"
         RELEASE = "${RELEASE}"


### PR DESCRIPTION
`docker bake` use the environment variable to override the values of the variables in the hcl file, and `USERNAME` is already defined in most unix system. This changes the name to REGISTRY_USER to avoid the conflict.

This PR also allows pushing on different registry (like ghcr.io)